### PR TITLE
Use internal path for plugins

### DIFF
--- a/kitchenSink/configBarChart.json
+++ b/kitchenSink/configBarChart.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "vertical",
@@ -11,7 +11,7 @@
     }
   },
   "barChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -26,7 +26,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -35,7 +35,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "barChartCSVLoader.data -> barChart.data"

--- a/kitchenSink/configBarLineEditor.json
+++ b/kitchenSink/configBarLineEditor.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -18,13 +18,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "barChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -45,7 +45,7 @@
     }
   },
   "lineChart": {
-    "plugin": "lineChart",
+    "plugin": "chiasm/plugins/lineChart",
     "state": {
       "xColumn": "timestamp",
       "xAxisLabel": "Time",
@@ -65,7 +65,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -74,7 +74,7 @@
     }
   },
   "lineChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleTime.csv",
       "numericColumns": [
@@ -86,7 +86,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "barChartCSVLoader.data -> barChart.data",

--- a/kitchenSink/configBarLineEditor2.json
+++ b/kitchenSink/configBarLineEditor2.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -18,13 +18,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "barChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -45,7 +45,7 @@
     }
   },
   "lineChart": {
-    "plugin": "lineChart",
+    "plugin": "chiasm/plugins/lineChart",
     "state": {
       "xColumn": "timestamp",
       "xAxisLabel": "Time",
@@ -65,7 +65,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -74,7 +74,7 @@
     }
   },
   "lineChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleTime.csv",
       "numericColumns": [
@@ -86,7 +86,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "barChartCSVLoader.data -> barChart.data",

--- a/kitchenSink/configBarLineEditor3.json
+++ b/kitchenSink/configBarLineEditor3.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -18,13 +18,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "barChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -46,7 +46,7 @@
     }
   },
   "lineChart": {
-    "plugin": "lineChart",
+    "plugin": "chiasm/plugins/lineChart",
     "state": {
       "xColumn": "timestamp",
       "xAxisLabel": "Time",
@@ -66,7 +66,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -75,7 +75,7 @@
     }
   },
   "lineChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleTime.csv",
       "numericColumns": [
@@ -87,7 +87,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "barChartCSVLoader.data -> barChart.data",

--- a/kitchenSink/configLineChart.json
+++ b/kitchenSink/configLineChart.json
@@ -1,12 +1,12 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": "lineChart"
     }
   },
   "lineChart": {
-    "plugin": "lineChart",
+    "plugin": "chiasm/plugins/lineChart",
     "state": {
       "xColumn": "timestamp",
       "xAxisLabel": "Time",
@@ -26,7 +26,7 @@
     }
   },
   "lineChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleTime.csv",
       "numericColumns": [
@@ -38,7 +38,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "lineChartCSVLoader.data -> lineChart.data"

--- a/kitchenSink/configScatterPlot.json
+++ b/kitchenSink/configScatterPlot.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -37,7 +37,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -46,7 +46,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -58,7 +58,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot2.json
+++ b/kitchenSink/configScatterPlot2.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -38,7 +38,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -47,7 +47,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -59,7 +59,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot3.json
+++ b/kitchenSink/configScatterPlot3.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -39,7 +39,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -48,7 +48,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -60,7 +60,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot4.json
+++ b/kitchenSink/configScatterPlot4.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -49,7 +49,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -58,7 +58,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -70,7 +70,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot5.json
+++ b/kitchenSink/configScatterPlot5.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -49,7 +49,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -58,7 +58,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -70,7 +70,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot6.json
+++ b/kitchenSink/configScatterPlot6.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -52,7 +52,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -61,7 +61,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -73,7 +73,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot7.json
+++ b/kitchenSink/configScatterPlot7.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "sepal_length",
       "xAxisLabel": "Sepal Length",
@@ -52,7 +52,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -61,7 +61,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -73,7 +73,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/configScatterPlot8.json
+++ b/kitchenSink/configScatterPlot8.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -12,13 +12,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "scatterPlot": {
-    "plugin": "scatterPlot",
+    "plugin": "chiasm/plugins/scatterPlot",
     "state": {
       "xColumn": "petal_width",
       "xAxisLabel": "Petal Width",
@@ -52,7 +52,7 @@
     }
   },
   "barChartCSVLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -61,7 +61,7 @@
     }
   },
   "iris": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "iris.csv",
       "numericColumns": [
@@ -73,7 +73,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "iris.data -> scatterPlot.data"

--- a/kitchenSink/requireJSConfig.js
+++ b/kitchenSink/requireJSConfig.js
@@ -11,12 +11,10 @@
 
   // Here's how to can use a local development version
   // if this Gist is cloned into a sibling directory to the chiasm repo.
-  var chiasmPath = "../../chiasm/src/";
-  
-  var plugins = chiasmPath + "plugins/";
+  var chiasmPath = "../src/";
 
   requirejs.config({
-  
+
     // Set up paths for Bower dependencies.
     // Uses github.com/curran/cdn
     paths: {
@@ -24,38 +22,28 @@
       // Set up the Chiasm path.
       // https://github.com/curran/chiasm
       chiasm: chiasmPath + "chiasm",
-  
-      // Configure paths for Chiasm pluginss.
-      layout: plugins + "layout",
-      computeLayout: plugins + "computeLayout",
-      configEditor: plugins + "configEditor",
-      csvLoader: plugins + "csvLoader",
-      links: plugins + "links",
-      reactivis: plugins + "reactivis",
-      barChart: plugins + "barChart",
-      lineChart: plugins + "lineChart",
-      scatterPlot: plugins + "scatterPlot",
-  
+      "chiasm/plugins": chiasmPath + "plugins",
+
       // Visualization library.
       // http://d3js.org/
       d3: "//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min",
-  
+
       // Reactive model library.
       // https://github.com/curran/model
       model: "//curran.github.io/cdn/model-v0.2.1/dist/model",
-  
+
       // Functional programming utilities.
       // http://benmccormick.org/2014/11/12/underscore-vs-lodash/
       lodash: "//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min",
-  
+
       // Asynchronous control flow.
       // https://github.com/caolan/async
       async: "//cdnjs.cloudflare.com/ajax/libs/async/0.9.0/async",
-  
+
       // Syntax-highlighted text editor for code.
       // http://codemirror.net/
       codemirror: "//curran.github.io/cdn/codemirror-v5.0.0",
-  
+
       // Provides interactive color picker and slider for CodeMirror.
       // https://github.com/enjalot/Inlet.git
       inlet: "//curran.github.io/cdn/inlet/inlet",

--- a/kitchenSink/visConfig2.json
+++ b/kitchenSink/visConfig2.json
@@ -1,6 +1,6 @@
 {
   "layout": {
-    "plugin": "layout",
+    "plugin": "chiasm/plugins/layout",
     "state": {
       "layout": {
         "orientation": "horizontal",
@@ -18,13 +18,13 @@
     }
   },
   "editor": {
-    "plugin": "configEditor",
+    "plugin": "chiasm/plugins/configEditor",
     "state": {
       "size": "325px"
     }
   },
   "barChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -47,7 +47,7 @@
     }
   },
   "pieChart": {
-    "plugin": "barChart",
+    "plugin": "chiasm/plugins/barChart",
     "state": {
       "xColumn": "letter",
       "xAxisLabel": "Letter",
@@ -70,7 +70,7 @@
     }
   },
   "dataLoader": {
-    "plugin": "csvLoader",
+    "plugin": "chiasm/plugins/csvLoader",
     "state": {
       "csvPath": "simpleBars.csv",
       "numericColumns": [
@@ -79,7 +79,7 @@
     }
   },
   "links": {
-    "plugin": "links",
+    "plugin": "chiasm/plugins/links",
     "state": {
       "bindings": [
         "dataLoader.data -> barChart.data",


### PR DESCRIPTION
Changed the way default plugins are referred in kitchenSink to match JSPM way.  (optional).
