### PR TITLE
Add new keyword before plugin constructor

### DIFF
--- a/src/chiasm.js
+++ b/src/chiasm.js
@@ -329,7 +329,7 @@ define(["model", "lodash","require"], function (Model, _, require) {
           try {
 
             // Construct the component using the plugin, passing the chiasm instance.
-            var component = constructor(chiasm);
+            var component = new constructor(chiasm);
 
             // Store a reference to the component.
             components[alias] = component;


### PR DESCRIPTION
Currently plugins are constructor functions (usually inherited from curran/model).  The new keyword is required by plugins that have been transpiled using babel.
