### PR TITLE
Update layout.js to add hook to remove window re-size event listener on destroy.

### DIFF
--- a/src/plugins/layout/layout.js
+++ b/src/plugins/layout/layout.js
@@ -33,6 +33,10 @@ function Layout(chiasm){
 
   // Update `model.box` on resize
   window.addEventListener("resize", setBox);
+  
+  model.destroy = function(){
+    window.removeEventListener("resize", setBox);
+  };
 
   // Respond to changes is box and layout.
   model.when(["layout", "sizes", "box"], function(layout, sizes, box){


### PR DESCRIPTION
Hook to destroy layout plugin and remove window resize event listener.   Fixes #36.
